### PR TITLE
HTTP Cacheデータを管理してディスクを圧迫しないように改善

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use secrecy::ExposeSecret;
+use tempfile::TempDir;
 
 use crate::{
     app::{
@@ -31,6 +32,7 @@ impl AppState {
     }
 
     pub async fn build_from_recorder_args(args: RecorderArgs) -> anyhow::Result<Self> {
+        let http_cache_dir = Arc::new(Self::http_cache_dir()?);
         let radyko_config = RadykoConfig::parse_from_path(args.config.config_path)?;
         let radiko_credential = RadikoCredential::load_credential();
         let radiko_client = match radiko_credential {
@@ -38,15 +40,17 @@ impl AppState {
                 RadikoClient::new_area_free(
                     c.email_address.expose_secret(),
                     c.password.expose_secret(),
+                    http_cache_dir,
                 )
                 .await?
             }
-            None => RadikoClient::new().await?,
+            None => RadikoClient::new(http_cache_dir).await?,
         };
         Self::new(radyko_config, radiko_client).await
     }
 
     pub async fn build_from_rule_args(args: RuleArgs) -> anyhow::Result<Self> {
+        let http_cache_dir = Arc::new(Self::http_cache_dir()?);
         let radyko_config = RadykoConfig::parse_from_path(args.config.config_path)?;
         let radiko_credential = RadikoCredential::load_credential();
         let radiko_client = match radiko_credential {
@@ -54,10 +58,11 @@ impl AppState {
                 RadikoClient::new_area_free(
                     c.email_address.expose_secret(),
                     c.password.expose_secret(),
+                    http_cache_dir,
                 )
                 .await?
             }
-            None => RadikoClient::new().await?,
+            None => RadikoClient::new(http_cache_dir).await?,
         };
         Self::new(radyko_config, radiko_client).await
     }
@@ -76,6 +81,10 @@ impl AppState {
             .unwrap()
             .recording
             .schedule_update_interval_secs
+    }
+
+    pub fn http_cache_dir() -> anyhow::Result<TempDir> {
+        Ok(TempDir::with_prefix("radyko_http_cache-")?)
     }
 }
 

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,19 +1,13 @@
-use std::io::{self, BufWriter, Write};
+use std::{
+    io::{self, BufWriter, Write},
+    sync::Arc,
+};
 
-use secrecy::ExposeSecret;
-
-use crate::{app::credential::RadikoCredential, cli::SearchArgs, radiko::RadikoClient};
+use crate::{app::state, cli::SearchArgs, radiko::RadikoClient};
 
 #[tracing::instrument(name = "cli_command_search")]
 pub async fn run(args: SearchArgs) -> anyhow::Result<()> {
-    let radiko_credential = RadikoCredential::load_credential();
-    let radiko_client = match radiko_credential {
-        Some(c) => {
-            RadikoClient::new_area_free(c.email_address.expose_secret(), c.password.expose_secret())
-                .await?
-        }
-        None => RadikoClient::new().await?,
-    };
+    let radiko_client = RadikoClient::new(Arc::new(state::AppState::http_cache_dir()?)).await?;
     let programs = radiko_client
         .search_programs(args.keyword, args.station_id.as_deref())
         .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,17 @@ pub mod telemetry;
 
 #[cfg(test)]
 pub mod test_helper {
+    use std::sync::Arc;
+
     use reqwest::Client;
     use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
     use secrecy::ExposeSecret;
     use tokio::sync::{self, OnceCell};
 
-    use crate::{app::credential::RadikoCredential, radiko::RadikoClient};
+    use crate::{
+        app::{credential::RadikoCredential, state},
+        radiko::RadikoClient,
+    };
 
     static CLIENT: std::sync::OnceLock<ClientWithMiddleware> = std::sync::OnceLock::new();
     static RADIKO_CLIENT: sync::OnceCell<RadikoClient> = OnceCell::const_new();
@@ -25,7 +30,11 @@ pub mod test_helper {
 
     pub async fn radiko_client() -> &'static RadikoClient {
         RADIKO_CLIENT
-            .get_or_init(|| async { RadikoClient::new().await.unwrap() })
+            .get_or_init(|| async {
+                RadikoClient::new(Arc::new(state::AppState::http_cache_dir().unwrap()))
+                    .await
+                    .unwrap()
+            })
             .await
     }
 
@@ -36,6 +45,7 @@ pub mod test_helper {
                 RadikoClient::new_area_free(
                     credential.email_address.expose_secret(),
                     credential.password.expose_secret(),
+                    Arc::new(state::AppState::http_cache_dir().unwrap()),
                 )
                 .await
                 .unwrap()

--- a/src/radiko/client.rs
+++ b/src/radiko/client.rs
@@ -1,8 +1,9 @@
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 use http_cache_reqwest::{CACacheManager, Cache, CacheMode, HttpCache, HttpCacheOptions};
 use reqwest::Client;
 use reqwest_middleware::ClientBuilder;
+use tempfile::TempDir;
 
 use crate::{
     model::program::{Program, Programs},
@@ -26,23 +27,25 @@ struct RadikoClientRef {
     stream: RadikoStream,
     program: RadikoProgram,
     search: RadikoSearch,
+    http_cache_dir: Arc<TempDir>,
 }
 
 impl RadikoClient {
     pub async fn new_area_free(
         email_address: &str,
         password: &str,
+        http_cache_dir: Arc<TempDir>,
     ) -> anyhow::Result<RadikoClient> {
-        Self::init(Some(email_address), Some(password)).await
+        Self::init(Some(email_address), Some(password), http_cache_dir).await
     }
 
-    pub async fn new() -> anyhow::Result<RadikoClient> {
-        Self::init(None, None).await
+    pub async fn new(http_cache_dir: Arc<TempDir>) -> anyhow::Result<RadikoClient> {
+        Self::init(None, None, http_cache_dir).await
     }
 
     pub async fn refresh_auth(&self) -> anyhow::Result<RadikoClient> {
         let refreshed_auth = self.inner.auth.refresh_auth().await?;
-        let inner = Self::build_inner(refreshed_auth);
+        let inner = Self::build_inner(refreshed_auth, Arc::clone(&self.inner.http_cache_dir));
 
         Ok(Self {
             default_area_id: Arc::new(inner.auth.area_id().to_string()),
@@ -100,8 +103,12 @@ impl RadikoClient {
             .await
     }
 
-    async fn init(email_address: Option<&str>, password: Option<&str>) -> anyhow::Result<Self> {
-        let inner = Self::init_inner(email_address, password).await?;
+    async fn init(
+        email_address: Option<&str>,
+        password: Option<&str>,
+        http_cache_dir: Arc<TempDir>,
+    ) -> anyhow::Result<Self> {
+        let inner = Self::init_inner(email_address, password, http_cache_dir).await?;
 
         Ok(Self {
             default_area_id: Arc::new(inner.auth.area_id().to_string()),
@@ -112,6 +119,7 @@ impl RadikoClient {
     async fn init_inner(
         email_address: Option<&str>,
         password: Option<&str>,
+        http_cache_dir: Arc<TempDir>,
     ) -> anyhow::Result<RadikoClientRef> {
         let is_area_free = email_address.is_some() && password.is_some();
         let radiko_auth = if is_area_free {
@@ -120,14 +128,14 @@ impl RadikoClient {
             RadikoAuth::new().await
         };
 
-        Ok(Self::build_inner(radiko_auth))
+        Ok(Self::build_inner(radiko_auth, http_cache_dir))
     }
 
-    fn build_inner(radiko_auth: RadikoAuth) -> RadikoClientRef {
+    fn build_inner(radiko_auth: RadikoAuth, http_cache_dir: Arc<TempDir>) -> RadikoClientRef {
         let client = ClientBuilder::new(Client::new())
             .with(Cache(HttpCache {
                 mode: CacheMode::Default,
-                manager: CACacheManager::new(PathBuf::from("./radyko_cache"), false),
+                manager: CACacheManager::new(http_cache_dir.path().into(), false),
                 options: HttpCacheOptions::default(),
             }))
             .build();
@@ -137,6 +145,7 @@ impl RadikoClient {
             stream: RadikoStream::new(radiko_auth.clone()),
             program: RadikoProgram::new(client.clone()),
             search: RadikoSearch::new(client.clone()),
+            http_cache_dir,
         }
     }
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -4,11 +4,13 @@
 pub mod tests_common {
     use std::io::BufReader;
     use std::io::Cursor;
+    use std::sync::Arc;
 
     use chrono::DateTime;
     use chrono_tz::Tz;
 
     use radyko::app::config;
+    use radyko::app::state;
     use radyko::model::Program;
     use radyko::{app::config::RadykoConfig, radiko::RadikoClient};
     use tokio::sync::OnceCell;
@@ -30,7 +32,11 @@ pub mod tests_common {
 
     pub async fn radiko_client() -> &'static RadikoClient {
         RADIKO_CLIENT
-            .get_or_init(|| async { RadikoClient::new().await.unwrap() })
+            .get_or_init(|| async {
+                RadikoClient::new(Arc::new(state::AppState::http_cache_dir().unwrap()))
+                    .await
+                    .unwrap()
+            })
             .await
     }
 


### PR DESCRIPTION
HTTP Cacheデータを固定のディレクトリに永続化しており、削除処理が実装されておらずディスクを圧迫していた。
`tempfile::TempDir`で生成した一時ディレクトリにキャッシュを保持することで、`radyko`プロセスのライフタイムでHTTP Cacheを削除するように改善。

Closes #29